### PR TITLE
Implement character creation flow

### DIFF
--- a/backend/tests/character.test.ts
+++ b/backend/tests/character.test.ts
@@ -1,0 +1,39 @@
+import request from 'supertest';
+import app from '../src/index';
+
+const archetype = {
+  id: 'knight',
+  name: 'Knight',
+  description: 'A brave warrior',
+  avatarUrl: 'placeholder',
+  stats: { hp: 10, attack: 5, defense: 5 },
+};
+
+describe('character persistence', () => {
+  it('saves character and retrieves it after re-login', async () => {
+    await request(app)
+      .post('/api/signup')
+      .send({ email: 'c@d.com', password: 'pass' })
+      .expect(200);
+    let res = await request(app)
+      .post('/api/login')
+      .send({ email: 'c@d.com', password: 'pass' })
+      .expect(200);
+    const token1 = res.body.token as string;
+    await request(app)
+      .post('/api/character')
+      .set('Authorization', 'Bearer ' + token1)
+      .send({ archetype })
+      .expect(200);
+    res = await request(app)
+      .post('/api/login')
+      .send({ email: 'c@d.com', password: 'pass' })
+      .expect(200);
+    const token2 = res.body.token as string;
+    const charRes = await request(app)
+      .get('/api/character')
+      .set('Authorization', 'Bearer ' + token2)
+      .expect(200);
+    expect(charRes.body.name).toBe('Knight');
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,26 @@
-/* eslint-disable */
-import React from "react";
+import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate, Link } from 'react-router-dom';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import CreateCharacter from './CreateCharacter';
+import World from './World';
 
 function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      fetch('http://localhost:3001/api/character', {
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((res) => {
+        if (res.ok) {
+          window.location.href = '/world';
+        } else {
+          window.location.href = '/create-character';
+        }
+      });
+    }
+  }, []);
   const handleLogin = async () => {
     const res = await fetch('http://localhost:3001/api/login', {
       method: 'POST',
@@ -16,7 +31,14 @@ function Login() {
     if (res.ok) {
       localStorage.setItem('token', data.token);
       localStorage.setItem('email', data.email);
-      window.location.href = '/dashboard';
+      const check = await fetch('http://localhost:3001/api/character', {
+        headers: { Authorization: `Bearer ${data.token}` },
+      });
+      if (check.ok) {
+        window.location.href = '/world';
+      } else {
+        window.location.href = '/create-character';
+      }
     } else {
       alert(data.error);
     }
@@ -60,11 +82,6 @@ function Signup() {
   );
 }
 
-function Dashboard() {
-  const email = localStorage.getItem('email');
-  return <div>Hello, {email}</div>;
-}
-
 function Protected({ children }: { children: React.ReactElement }) {
   const token = localStorage.getItem('token');
   return token ? children : <Navigate to="/" replace />;
@@ -76,7 +93,8 @@ function App() {
       <Routes>
         <Route path="/" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
-        <Route path="/dashboard" element={<Protected><Dashboard /></Protected>} />
+        <Route path="/create-character" element={<Protected><CreateCharacter /></Protected>} />
+        <Route path="/world" element={<Protected><World /></Protected>} />
       </Routes>
     </Router>
   );

--- a/frontend/src/CreateCharacter.tsx
+++ b/frontend/src/CreateCharacter.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { Archetype, generateArchetypes } from './generateArchetypes';
+
+export default function CreateCharacter() {
+  const [archetypes] = useState<Archetype[]>(generateArchetypes());
+
+  const choose = async (a: Archetype) => {
+    const token = localStorage.getItem('token');
+    if (!token) return;
+    await fetch('http://localhost:3001/api/character', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ archetype: a }),
+    });
+    window.location.href = '/world';
+  };
+
+  return (
+    <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+      {archetypes.map((a) => (
+        <div key={a.id} style={{ border: '1px solid #ccc', padding: '1rem' }}>
+          <h3>{a.name}</h3>
+          <img src={a.avatarUrl} alt={a.name} width={100} height={100} />
+          <p>{a.description}</p>
+          <ul>
+            <li>HP: {a.stats.hp}</li>
+            <li>Attack: {a.stats.attack}</li>
+            <li>Defense: {a.stats.defense}</li>
+          </ul>
+          <button onClick={() => choose(a)}>Choose</button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/Login.test.tsx
+++ b/frontend/src/Login.test.tsx
@@ -1,4 +1,7 @@
-jest.mock('react-router-dom', () => ({ Link: (props: any) => <a {...props} /> }));
+jest.mock('react-router-dom', () => ({
+  Link: (props: React.ComponentProps<'a'>) => <a {...props} />,
+}));
+import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Login } from './App';
 

--- a/frontend/src/World.tsx
+++ b/frontend/src/World.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { Archetype } from './generateArchetypes';
+
+export default function World() {
+  const [character, setCharacter] = useState<Archetype | null>(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) return;
+    fetch('http://localhost:3001/api/character', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setCharacter(data));
+  }, []);
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('email');
+    window.location.href = '/';
+  };
+
+  if (!character) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2>{character.name}</h2>
+      <img src={character.avatarUrl} alt={character.name} width={100} height={100} />
+      <ul>
+        <li>HP: {character.stats.hp}</li>
+        <li>Attack: {character.stats.attack}</li>
+        <li>Defense: {character.stats.defense}</li>
+      </ul>
+      <button onClick={logout}>Log Out</button>
+    </div>
+  );
+}

--- a/frontend/src/generateArchetypes.test.ts
+++ b/frontend/src/generateArchetypes.test.ts
@@ -1,0 +1,23 @@
+import { generateArchetypes } from './generateArchetypes';
+
+test('generateArchetypes returns three unique archetypes with required keys', () => {
+  const archetypes = generateArchetypes();
+  expect(archetypes).toHaveLength(3);
+  const ids = new Set(archetypes.map(a => a.id));
+  expect(ids.size).toBe(3);
+  archetypes.forEach(a => {
+    expect(a).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        name: expect.any(String),
+        description: expect.any(String),
+        avatarUrl: expect.any(String),
+        stats: {
+          hp: expect.any(Number),
+          attack: expect.any(Number),
+          defense: expect.any(Number),
+        },
+      })
+    );
+  });
+});

--- a/frontend/src/generateArchetypes.ts
+++ b/frontend/src/generateArchetypes.ts
@@ -1,0 +1,37 @@
+export interface Archetype {
+  id: string;
+  name: string;
+  description: string;
+  avatarUrl: string;
+  stats: {
+    hp: number;
+    attack: number;
+    defense: number;
+  };
+}
+
+export function generateArchetypes(): Archetype[] {
+  return [
+    {
+      id: 'knight',
+      name: 'Knight',
+      description: 'Armored warrior with unmatched defense.',
+      avatarUrl: 'https://placekitten.com/200/200',
+      stats: { hp: 120, attack: 8, defense: 15 },
+    },
+    {
+      id: 'mage',
+      name: 'Mage',
+      description: 'Master of arcane arts with powerful attacks.',
+      avatarUrl: 'https://placekitten.com/201/200',
+      stats: { hp: 80, attack: 15, defense: 5 },
+    },
+    {
+      id: 'ranger',
+      name: 'Ranger',
+      description: 'Swift archer striking from afar.',
+      avatarUrl: 'https://placekitten.com/200/201',
+      stats: { hp: 100, attack: 10, defense: 8 },
+    },
+  ];
+}

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,3 +1,3 @@
-import { TextEncoder } from "util";
-(global as any).TextEncoder = TextEncoder;
+import { TextEncoder } from 'util';
+(global as unknown as { TextEncoder: typeof TextEncoder }).TextEncoder = TextEncoder;
 import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add character archetype backend model and endpoints
- auto-persist chosen archetype
- add world and character creation pages
- implement archetype generator helper and tests
- redirect users based on saved character

## Testing
- `npm --prefix frontend run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687962347c608333b4a0ac81157fcbb9