### PR TITLE
Cycle 4 implementation

### DIFF
--- a/frontend/src/World.css
+++ b/frontend/src/World.css
@@ -26,6 +26,9 @@
 .tile.road {
   background: #d2b48c;
 }
+.tile.challenge {
+  background: #ffff00;
+}
 .player {
   width: 32px;
   height: 32px;
@@ -33,4 +36,32 @@
 }
 .player.step1 {
   background: #cc0000;
+}
+
+.hud {
+  position: fixed;
+  top: 0;
+  left: 0;
+  padding: 0.5rem 1rem;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+}
+
+.modal,
+.win-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.7);
+  color: #000;
+}
+.modal > div,
+.win-overlay > div {
+  background: #fff;
+  padding: 1rem 2rem;
 }

--- a/frontend/src/World.tsx
+++ b/frontend/src/World.tsx
@@ -1,14 +1,46 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Archetype } from "./generateArchetypes";
 import { generateMap, TileType } from "./generateMap";
+import { generateMathProblem, MathProblem } from "./generateMathProblem";
 import "./World.css";
 
 export default function World() {
   const [character, setCharacter] = useState<Archetype | null>(null);
-  const [map] = useState<TileType[][]>(() => generateMap(1));
+  const [map, setMap] = useState<TileType[][]>(() => generateMap());
   const [position, setPosition] = useState({ x: 25, y: 25 });
   const [step, setStep] = useState(0);
+  const [points, setPoints] = useState(() => {
+    const stored = sessionStorage.getItem("points");
+    return stored ? Number(stored) : 0;
+  });
+  const [challenge, setChallenge] = useState<
+    | { pos: { x: number; y: number }; problem: MathProblem; attempts: number }
+    | null
+  >(null);
+  const [win, setWin] = useState(false);
   const lastMove = useRef(0);
+  const [inputAnswer, setInputAnswer] = useState("");
+
+  const closeChallenge = React.useCallback(() => {
+    if (!challenge) return;
+    const newMap = map.map((row) => row.slice());
+    newMap[challenge.pos.y][challenge.pos.x] = "grass";
+    setMap(newMap);
+    setChallenge(null);
+  }, [challenge, map]);
+
+  const submitAnswer = () => {
+    if (!challenge) return;
+    if (parseInt(inputAnswer, 10) === challenge.problem.answer) {
+      setPoints((p) => p + challenge.problem.points);
+      closeChallenge();
+    } else if (challenge.attempts === 0) {
+      setChallenge({ ...challenge, attempts: 1 });
+    } else {
+      closeChallenge();
+    }
+    setInputAnswer("");
+  };
 
   useEffect(() => {
     const token = localStorage.getItem("token");
@@ -27,7 +59,22 @@ export default function World() {
   };
 
   useEffect(() => {
+    if (!challenge) return;
+    const esc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeChallenge();
+    };
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [challenge, closeChallenge]);
+
+  useEffect(() => {
+    sessionStorage.setItem("points", points.toString());
+    if (points >= 10) setWin(true);
+  }, [points]);
+
+  useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      if (challenge || win) return;
       const now = Date.now();
       if (now - lastMove.current < 166) return;
       lastMove.current = now;
@@ -39,17 +86,32 @@ export default function World() {
       else if (e.key === "ArrowRight" || e.key.toLowerCase() === "d") dx = 1;
       if (dx === 0 && dy === 0) return;
       setStep((s) => 1 - s);
+      let open = false;
+      let cx = 0;
+      let cy = 0;
       setPosition((p) => {
         const nx = Math.max(0, Math.min(49, p.x + dx));
         const ny = Math.max(0, Math.min(49, p.y + dy));
         const tile = map[ny][nx];
         if (tile === "water" || tile === "mountain") return p;
+        if (tile === "challenge") {
+          open = true;
+          cx = nx;
+          cy = ny;
+        }
         return { x: nx, y: ny };
       });
+      if (open) {
+        setChallenge({
+          pos: { x: cx, y: cy },
+          problem: generateMathProblem((Math.floor(Math.random() * 3) + 1) as 1 | 2 | 3),
+          attempts: 0,
+        });
+      }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [map]);
+  }, [map, challenge, win]);
 
   if (!character) return <div>Loading...</div>;
 
@@ -77,6 +139,7 @@ export default function World() {
 
   return (
     <div>
+      <div className="hud">Points: {points}/10</div>
       <h2>{character.name}</h2>
       <img
         src={character.avatarUrl}
@@ -93,6 +156,39 @@ export default function World() {
       <div data-testid="world" className="world">
         {tiles}
       </div>
+      {challenge && (
+        <div className="modal" role="dialog">
+          <div>
+            <h3>Math Challenge!</h3>
+            <p>{challenge.problem.question}</p>
+            <input
+              autoFocus
+              value={inputAnswer}
+              onChange={(e) => setInputAnswer(e.target.value)}
+            />
+            <button onClick={submitAnswer}>Submit</button>
+          </div>
+        </div>
+      )}
+      {win && (
+        <div className="win-overlay">
+          <div>
+            <h2>You Win!</h2>
+            <p>Total Points: {points}</p>
+            <button
+              onClick={() => {
+                setPoints(0);
+                sessionStorage.setItem("points", "0");
+                setMap(generateMap());
+                setPosition({ x: 25, y: 25 });
+                setWin(false);
+              }}
+            >
+              Play Again
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/WorldWin.test.tsx
+++ b/frontend/src/WorldWin.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import World from './World';
+import { Archetype } from './generateArchetypes';
+
+jest.mock('./generateMap', () => ({
+  generateMap: () => Array.from({ length: 50 }, () => Array(50).fill('grass')),
+}));
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({
+      id: 'knight',
+      name: 'Knight',
+      description: '',
+      avatarUrl: 'x',
+      stats: { hp: 1, attack: 1, defense: 1 },
+    } as Archetype),
+  }),
+) as unknown as typeof fetch;
+
+Object.defineProperty(window, 'localStorage', {
+  value: {
+    getItem: () => 'token',
+    removeItem: jest.fn(),
+  },
+});
+
+Object.defineProperty(window, 'sessionStorage', {
+  value: {
+    getItem: () => '10',
+    setItem: jest.fn(),
+  },
+});
+
+test('shows win overlay when points >= 10 and restarts', async () => {
+  render(<World />);
+  expect(await screen.findByText(/You Win!/)).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Play Again'));
+  expect(screen.queryByText(/You Win!/)).not.toBeInTheDocument();
+});

--- a/frontend/src/generateMap.test.ts
+++ b/frontend/src/generateMap.test.ts
@@ -1,7 +1,7 @@
 import { generateMap, TileType } from "./generateMap";
 
 test("generateMap returns a 50x50 array of valid tiles", () => {
-  const tiles = ["grass", "forest", "water", "mountain", "road"];
+  const tiles = ["grass", "forest", "water", "mountain", "road", "challenge"];
   const map = generateMap(1);
   expect(map).toHaveLength(50);
   map.forEach((row) => {
@@ -10,4 +10,9 @@ test("generateMap returns a 50x50 array of valid tiles", () => {
       expect(tiles).toContain(tile as TileType);
     });
   });
+  let challengeCount = 0;
+  for (const row of map) {
+    for (const tile of row) if (tile === "challenge") challengeCount += 1;
+  }
+  expect(challengeCount).toBe(15);
 });

--- a/frontend/src/generateMap.ts
+++ b/frontend/src/generateMap.ts
@@ -1,4 +1,10 @@
-export type TileType = "grass" | "forest" | "water" | "mountain" | "road";
+export type TileType =
+  | "grass"
+  | "forest"
+  | "water"
+  | "mountain"
+  | "road"
+  | "challenge";
 
 function mulberry32(seed: number): () => number {
   let t = seed + 0x6d2b79f5;
@@ -25,6 +31,15 @@ export function generateMap(seed = Date.now()): TileType[][] {
       row.push(tile);
     }
     map.push(row);
+  }
+  let placed = 0;
+  while (placed < 15) {
+    const x = Math.floor(rand() * 50);
+    const y = Math.floor(rand() * 50);
+    const tile = map[y][x];
+    if (tile === "water" || tile === "mountain" || tile === "challenge") continue;
+    map[y][x] = "challenge";
+    placed += 1;
   }
   return map;
 }

--- a/frontend/src/generateMathProblem.test.ts
+++ b/frontend/src/generateMathProblem.test.ts
@@ -1,0 +1,31 @@
+import { generateMathProblem } from './generateMathProblem';
+
+describe('generateMathProblem', () => {
+  test('difficulty 1 within 0-20', () => {
+    for (let i = 0; i < 20; i += 1) {
+      const { question, answer, points } = generateMathProblem(1);
+      expect(typeof question).toBe('string');
+      expect(typeof answer).toBe('number');
+      expect(points).toBe(1);
+      expect(answer).toBeLessThanOrEqual(20);
+    }
+  });
+
+  test('difficulty 2 subtraction/multiplication <=100', () => {
+    for (let i = 0; i < 20; i += 1) {
+      const { answer, points } = generateMathProblem(2);
+      expect(points).toBe(2);
+      expect(Math.abs(answer)).toBeLessThanOrEqual(100);
+    }
+  });
+
+  test('difficulty 3 division exact', () => {
+    for (let i = 0; i < 20; i += 1) {
+      const { question, answer, points } = generateMathProblem(3);
+      expect(points).toBe(3);
+      expect(answer).toBeGreaterThanOrEqual(1);
+      expect(answer).toBeLessThanOrEqual(12);
+      expect(question).toMatch(/\u00F7/);
+    }
+  });
+});

--- a/frontend/src/generateMathProblem.ts
+++ b/frontend/src/generateMathProblem.ts
@@ -1,0 +1,38 @@
+export interface MathProblem {
+  question: string;
+  answer: number;
+  points: 1 | 2 | 3;
+}
+
+export function generateMathProblem(difficulty: 1 | 2 | 3): MathProblem {
+  if (difficulty === 1) {
+    const a = Math.floor(Math.random() * 11);
+    const b = Math.floor(Math.random() * 11);
+    if (Math.random() < 0.5) {
+      return { question: `${a} + ${b}`, answer: a + b, points: 1 };
+    }
+    const big = a + b <= 20 ? a + b : 20;
+    const c = Math.floor(Math.random() * (big + 1));
+    return { question: `${big} - ${c}`, answer: big - c, points: 1 };
+  }
+
+  if (difficulty === 2) {
+    if (Math.random() < 0.5) {
+      const a = Math.floor(Math.random() * 50) + 1;
+      const b = Math.floor(Math.random() * 50) + 1;
+      return { question: `${a} - ${b}`, answer: a - b, points: 2 };
+    }
+    const a = Math.floor(Math.random() * 10) + 1;
+    const b = Math.floor(Math.random() * 10) + 1;
+    return { question: `${a} \u00d7 ${b}`, answer: a * b, points: 2 };
+  }
+
+  const divisor = Math.floor(Math.random() * 12) + 1;
+  const quotient = Math.floor(Math.random() * 12) + 1;
+  const dividend = divisor * quotient;
+  return {
+    question: `${dividend} \u00F7 ${divisor}`,
+    answer: quotient,
+    points: 3,
+  };
+}


### PR DESCRIPTION
## Summary
- add `challenge` tiles to map generation and random placement
- implement math problem generator
- display HUD with points and modal challenge overlay
- create win overlay and restart logic
- update styles for challenge tiles and overlays
- add unit and integration tests for new functionality

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68797e09c7bc8333bec9a4cd6d78febc